### PR TITLE
Add Python 3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
    <img src="https://raw.githubusercontent.com/openbaton/openbaton.github.io/master/images/openBaton.png" width="250"/>
-  
-  Copyright © 2015-2016 [Open Baton](http://openbaton.org). 
+
+  Copyright © 2015-2016 [Open Baton](http://openbaton.org).
   Licensed under [Apache v2 License](http://www.apache.org/licenses/LICENSE-2.0).
 
 # Python version of the vnfm-sdk
@@ -9,18 +9,18 @@ This project contains a vnfm sdk for python projects.
 ## Technical Requirements
 This section covers the requirements that must be met by the python-vnfm-sdk in order to satisfy the demands for such a component:
 
-* python 2.7
+* python 2.7 or 3.5
 * pika
 
 ## How to install python-vfnm-sdk
 
-The safer way to start is to use a [virtal environment](https://virtualenv.pypa.io/en/stable/). Once activated, just run 
- 
+The safer way to start is to use a [virtal environment](https://virtualenv.pypa.io/en/stable/). Once activated, just run
+
  ```bash
  python setup.py build
  python setup.py install
  ```
- 
+
 After that, in this virtual environment a module *interfaces* will be available from which you can inherit the AbstractVnfm class in this way:
 
 ```python
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     vnfm.run()
 
 ```
- 
+
 ## Issue tracker
 
 Issues and bug reports should be posted to the GitHub Issue Tracker of this project
@@ -76,7 +76,7 @@ Issues and bug reports should be posted to the GitHub Issue Tracker of this proj
 
 OpenBaton is an open source project providing a comprehensive implementation of the ETSI Management and Orchestration (MANO) specification.
 
-Open Baton is a ETSI NFV MANO compliant framework. Open Baton was part of the OpenSDNCore (www.opensdncore.org) project started almost three years ago by Fraunhofer FOKUS with the objective of providing a compliant implementation of the ETSI NFV specification. 
+Open Baton is a ETSI NFV MANO compliant framework. Open Baton was part of the OpenSDNCore (www.opensdncore.org) project started almost three years ago by Fraunhofer FOKUS with the objective of providing a compliant implementation of the ETSI NFV specification.
 
 Open Baton is easily extensible. It integrates with OpenStack, and provides a plugin mechanism for supporting additional VIM types. It supports Network Service management either using a generic VNFM or interoperating with VNF-specific VNFM. It uses different mechanisms (REST or PUB/SUB) for interoperating with the VNFMs. It integrates with additional components for the runtime management of a Network Service. For instance, it provides autoscaling and fault management based on monitoring information coming from the the monitoring system available at the NFVI level.
 

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Technical Requirements
 This section covers the requirements that must be met by the
 python-vnfm-sdk in order to satisfy the demands for such a component:
 
--  python 2.7
+-  python 2.7 or 3.5
 -  pika
 
 How to install the python-vfnm-sdk
@@ -18,7 +18,7 @@ How to install the python-vfnm-sdk
 The safer way to start is to use a `virtual environment <https://virtualenv.pypa.io/en/stable/>`__. Once activated, just run
 
 .. code:: bash
- 
+
    pip install python-vnfm-sdk
 
 How to use the python-vfnm-sdk

--- a/vnfm/sdk/AbstractVnfmABC.py
+++ b/vnfm/sdk/AbstractVnfmABC.py
@@ -199,7 +199,10 @@ class AbstractVnfm(threading.Thread):
         :param body:
         :return:
         """
-        msg = json.loads(body)
+
+        # body is `str` in py2, `bytes` in py3; decode makes it a unicode string
+        # suitable for json.loads()
+        msg = json.loads(body.decode('utf-8'))
 
         action = msg.get("action")
         log.debug("Action is %s" % action)

--- a/vnfm/sdk/AbstractVnfmABC.py
+++ b/vnfm/sdk/AbstractVnfmABC.py
@@ -371,7 +371,13 @@ class AbstractVnfm(threading.Thread):
             connection.process_data_events()
 
         channel.queue_delete(queue=callback_queue)
-        return json.loads(response["result"])
+
+        """
+        decode() ensures that this is a unicode string suitable for json
+        (json requires valid unicode), converting bytes into str in py3 and
+        str into unicode in py2.
+        """
+        return json.loads(response["result"].decode('utf-8'))
 
     def get_user_data(self):
         userdata_path = self._map.get("userdata_path", "/etc/openbaton/%s/userdata.sh" % self.type)


### PR DESCRIPTION
By changing a few lines in `vnfm/sdk/AbstractVnfmABC.py`, I've managed to achieve full compatibility with Python 3 (tested with Python 3.5.2), while retaining full backward compatibility with Python 2.7.

#### What changed:

- `ConfigParser` became `configparser` in Python 3. A `try-except` block has been added to handle both cases gracefully.
- Python 3 doesn't support implicit relative imports anymore; thus, another `try-except` block has been added to handle this difference.
- `threading.Thread` in Python 3 has a field named `_stop`; `self._stop` has been renamed to `self._stop_running` to resolve this conflict.
- pika returns raw strings (`str` in py2, bytes in py3), that need to be converted into UTF-8 before passing them to `json.loads()`. Calling `.decode('utf-8')` sanitizes the input in both cases, and fixes the TypeErrors caused by the str/bytes split of Python 3.